### PR TITLE
fix: handling process exits after restore

### DIFF
--- a/zeropod/restore.go
+++ b/zeropod/restore.go
@@ -56,6 +56,11 @@ func (c *Container) Restore(ctx context.Context) (*runc.Container, process.Proce
 	// the process is not yet restored.
 	container.CgroupSet(c.cgroup)
 
+	var handleStarted HandleStartedFunc
+	if c.preRestore != nil {
+		handleStarted = c.preRestore()
+	}
+
 	p, err := container.Process("")
 	if err != nil {
 		return nil, nil, err
@@ -76,8 +81,8 @@ func (c *Container) Restore(ctx context.Context) (*runc.Container, process.Proce
 	c.Container = container
 	c.process = p
 
-	if c.setContainer != nil {
-		c.setContainer(container)
+	if c.postRestore != nil {
+		c.postRestore(container, handleStarted)
 	}
 
 	// process is running again, we don't need to redirect traffic anymore


### PR DESCRIPTION
When deleting the container at a point in time where the process is restored our shim would not get the exit signal. To fix this we need to setup the process handlers on restore as if it was a new container. We do this by hooking into the lifecycle with the preRestore and postRestore functions. This allows us to call the relevant task service functions to setup the exit handlers after every restore.