### PR TITLE
feat(experimental): add grouping of multiple pods on one shim

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,6 +255,14 @@ zeropod.ctrox.dev/pre-dump: "true"
 # killed on scale-down and all state is lost. This might be useful for some
 # use-cases where the application is stateless and super fast to startup.
 zeropod.ctrox.dev/disable-checkpointing: "true"
+
+# Experimental:
+# It's possible to reduce the resource usage further by grouping multiple pods
+# into one shim process. The value of the annotation specifies the group id,
+# each of which will result in a shim process. This is currently marked as
+# experimental since not much testing has been done and new issues might
+# surface when using grouping.
+io.containerd.runc.v2.group: "zeropod"
 ```
 
 ## zeropod-node

--- a/cmd/installer/main.go
+++ b/cmd/installer/main.go
@@ -68,7 +68,8 @@ network-lock skip
     "zeropod.ctrox.dev/container-names",
     "zeropod.ctrox.dev/scaledown-duration",
     "zeropod.ctrox.dev/disable-checkpointing",
-    "zeropod.ctrox.dev/pre-dump"
+    "zeropod.ctrox.dev/pre-dump",
+    "io.containerd.runc.v2.group"
   ]
 `
 )

--- a/config/examples/nginx.yaml
+++ b/config/examples/nginx.yaml
@@ -1,15 +1,23 @@
-apiVersion: v1
-kind: Pod
+apiVersion: apps/v1
+kind: Deployment
 metadata:
   name: nginx
-  labels:
-    app: nginx
-  annotations:
-    zeropod.ctrox.dev/scaledown-duration: 10s
 spec:
-  runtimeClassName: zeropod
-  containers:
-    - name: nginx
-      image: nginx
-      ports:
-        - containerPort: 80
+  replicas: 3
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      labels:
+        app: nginx
+      annotations:
+        io.containerd.runc.v2.group: "zeropod"
+        zeropod.ctrox.dev/scaledown-duration: 10s
+    spec:
+      runtimeClassName: zeropod
+      containers:
+        - image: nginx
+          name: nginx
+          ports:
+            - containerPort: 80


### PR DESCRIPTION
Multiple pods can be grouped into one shim by setting the annotation `io.containerd.runc.v2.group: "zeropod"`. The value defines the group id for each of which one shim process is started. This commit ensures that annotation is passed to the shim and also fixes the metrics to properly cleanup when grouping and pods are removed.

This is currently marked as experimental since not much testing has been done and new issues might surface when using grouping.