### PR TITLE
Improve scheduling

### DIFF
--- a/cmd/installer/main.go
+++ b/cmd/installer/main.go
@@ -63,7 +63,8 @@ network-lock skip
 `
 	runtimeConfig = `
 [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.zeropod]
-  runtime_type = "io.containerd.zeropod.v2"
+  runtime_type = "io.containerd.runc.v2"
+  runtime_path = "%s/bin/containerd-shim-zeropod-v2"
   pod_annotations = [
     "zeropod.ctrox.dev/ports-map",
     "zeropod.ctrox.dev/container-names",
@@ -253,7 +254,7 @@ func configureContainerd(runtime containerRuntime, containerdConfig string) (res
 		return false, err
 	}
 
-	if _, err := cfg.WriteString(runtimeConfig); err != nil {
+	if _, err := cfg.WriteString(fmt.Sprintf(runtimeConfig, *hostOptPath)); err != nil {
 		return false, err
 	}
 

--- a/cmd/installer/main.go
+++ b/cmd/installer/main.go
@@ -15,6 +15,7 @@ import (
 	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/services/server/config"
 	"github.com/coreos/go-systemd/v22/dbus"
+	"github.com/ctrox/zeropod/zeropod"
 	nodev1 "k8s.io/api/node/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -319,6 +320,7 @@ func installRuntimeClass(ctx context.Context, client kubernetes.Interface) error
 	runtimeClass := &nodev1.RuntimeClass{
 		ObjectMeta: v1.ObjectMeta{Name: runtimeClassName},
 		Handler:    runtimeHandler,
+		Scheduling: &nodev1.Scheduling{NodeSelector: map[string]string{zeropod.NodeLabel: "true"}},
 	}
 
 	if _, err := client.NodeV1().RuntimeClasses().Create(ctx, runtimeClass, v1.CreateOptions{}); err != nil {

--- a/zeropod/config.go
+++ b/zeropod/config.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/containerd/containerd/namespaces"
 	"github.com/containerd/log"
 	"github.com/mitchellh/mapstructure"
 	"github.com/opencontainers/runtime-spec/specs-go"
@@ -28,6 +29,7 @@ const (
 	portsDelim               = containersDelim
 	mappingDelim             = ";"
 	mapDelim                 = "="
+	defaultContainerdNS      = "k8s.io"
 )
 
 type annotationConfig struct {
@@ -54,6 +56,7 @@ type Config struct {
 	PodName               string
 	PodNamespace          string
 	PodUID                string
+	ContainerdNamespace   string
 	spec                  *specs.Spec
 }
 
@@ -125,6 +128,11 @@ func NewConfig(ctx context.Context, spec *specs.Spec) (*Config, error) {
 		containerNames = strings.Split(cfg.ZeropodContainerNames, containersDelim)
 	}
 
+	ns, ok := namespaces.Namespace(ctx)
+	if !ok {
+		ns = defaultContainerdNS
+	}
+
 	return &Config{
 		Ports:                 containerPorts,
 		ScaleDownDuration:     dur,
@@ -136,6 +144,7 @@ func NewConfig(ctx context.Context, spec *specs.Spec) (*Config, error) {
 		PodName:               cfg.PodName,
 		PodNamespace:          cfg.PodNamespace,
 		PodUID:                cfg.PodUID,
+		ContainerdNamespace:   ns,
 		spec:                  spec,
 	}, nil
 }

--- a/zeropod/restore.go
+++ b/zeropod/restore.go
@@ -48,7 +48,7 @@ func (c *Container) Restore(ctx context.Context) (*runc.Container, process.Proce
 		createReq.Checkpoint = ""
 	}
 
-	container, err := runc.NewContainer(namespaces.WithNamespace(ctx, "k8s"), c.platform, createReq)
+	container, err := runc.NewContainer(namespaces.WithNamespace(ctx, c.cfg.ContainerdNamespace), c.platform, createReq)
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
This improves scheduling in two areas:
* The runtimeclass now sets the same label selector as the daemonset already has. This ensures that pods only get scheduled onto zeropod-enabled nodes.
* The runtime type has been changed to `io.containerd.runc.v2` so the containerd feature detection works properly. The shim binary is set using the `runtime_path` option. This will be important in the future for containerd v2 and features like user namespaces.

The other two commits contain bugfixes discovered during testing this.