### PR TITLE
ci: automate image version updates

### DIFF
--- a/.github/workflows/build_push.yml
+++ b/.github/workflows/build_push.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Log in to the Container registry
         uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
@@ -61,3 +61,22 @@ jobs:
           push: true
           tags: ${{ steps.meta_manager.outputs.tags }}
           labels: ${{ steps.meta_manager.outputs.labels }}
+
+  update-manifests:
+    name: Update Manifests
+    needs: push_to_registry
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Update Deployment Image Tag
+        working-directory: "config/production"
+        run: |
+          kustomize edit set image installer=${{ env.REGISTRY }}/${{ env.INSTALLER_IMAGE_NAME }}:${{ github.ref_name }}
+          kustomize edit set image manager=${{ env.REGISTRY }}/${{ env.MANAGER_IMAGE_NAME }}:${{ github.ref_name }}
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v6
+        with:
+          commit-message: "chore: update image versions"

--- a/.github/workflows/build_push_criu.yml
+++ b/.github/workflows/build_push_criu.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Log in to the Container registry
         uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
@@ -42,6 +42,7 @@ jobs:
           file: ./criu/Dockerfile
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: ${{ env.REGISTRY }}/${{ env.CRIU_IMAGE_NAME }}:${{ env.CRIU_VERSION }}
+          tags:
+            ${{ env.REGISTRY }}/${{ env.CRIU_IMAGE_NAME }}:${{env.CRIU_VERSION}}
           labels: ${{ steps.meta_criu.outputs.labels }}
           build-args: CRIU_VERSION=${{ env.CRIU_VERSION }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ jobs:
   staticcheck:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up Go
         uses: actions/setup-go@v4
@@ -21,7 +21,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up Go
         uses: actions/setup-go@v4
@@ -34,7 +34,7 @@ jobs:
   build:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
@@ -68,7 +68,7 @@ jobs:
   e2e:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2

--- a/config/production/kustomization.yaml
+++ b/config/production/kustomization.yaml
@@ -1,19 +1,21 @@
 resources:
-  - ../base
-images:
-  - name: manager
-    newName: ghcr.io/ctrox/zeropod-manager
-    newTag: v0.3.1
-  - name: installer
-    newName: ghcr.io/ctrox/zeropod-installer
-    newTag: v0.3.1
-patches:
-  - patch: |-
-      - op: add
-        path: /spec/template/spec/initContainers/0/args/-
-        value: -criu-image=ghcr.io/ctrox/zeropod-criu:v3.19
-    target:
-      kind: DaemonSet
+- ../base
 # uncommment to enable in-place scaling
 # components:
 #  - ../in-place-scaling
+images:
+- name: installer
+  newName: ghcr.io/ctrox/zeropod-installer
+  newTag: v0.3.1
+- name: manager
+  newName: ghcr.io/ctrox/zeropod-manager
+  newTag: v0.3.1
+patches:
+- patch: |-
+    - op: add
+      path: /spec/template/spec/initContainers/0/args/-
+      value: -criu-image=ghcr.io/ctrox/zeropod-criu:v3.19
+  target:
+    kind: DaemonSet
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization


### PR DESCRIPTION
Adds a github action to use kustomize to update the image versions to match the pushed tag and commit it back to the repo.