### PR TITLE
fix: make restore idempotent

### DIFF
--- a/runc/task/service_zeropod.go
+++ b/runc/task/service_zeropod.go
@@ -197,7 +197,6 @@ func (w *wrapper) Exec(ctx context.Context, r *taskAPI.ExecProcessRequest) (*emp
 			os.Exit(1)
 		}
 
-		zeropodContainer.SetScaledDown(false)
 		log.G(ctx).Printf("restored process for exec: %d in %s", p.Pid(), time.Since(beforeRestore))
 	}
 


### PR DESCRIPTION
The activator used a sync.Once to ensure onAccept is only called once per restore but that lead to an invalid unlock in rare cases since we had to reset the sync.Once when checkpointing. A more robust solution is to get rid of the sync.Once, call onAccept on every accept and then let the restore function handle being called multiple times.