### PR TITLE
ci: use branch to prepare for release

### DIFF
--- a/.github/workflows/build_push.yml
+++ b/.github/workflows/build_push.yml
@@ -61,25 +61,3 @@ jobs:
           push: true
           tags: ${{ steps.meta_manager.outputs.tags }}
           labels: ${{ steps.meta_manager.outputs.labels }}
-
-  update-manifests:
-    name: Update Manifests
-    needs: push_to_registry
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Update Deployment Image Tags
-        working-directory: "config/production"
-        run: |
-          kustomize edit set image installer=${{ env.REGISTRY }}/${{ env.INSTALLER_IMAGE_NAME }}:${{ github.ref_name }}
-          kustomize edit set image manager=${{ env.REGISTRY }}/${{ env.MANAGER_IMAGE_NAME }}:${{ github.ref_name }}
-
-      - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v6
-        with:
-          commit-message: "chore: update image versions"
-          title: "Update image versions"
-          base: main
-          branch-suffix: short-commit-hash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,39 @@
+name: Prepare Release
+
+on:
+  push:
+    branches:
+      - "release/v[012].[0-9]+.[0-9]+"
+
+env:
+  REGISTRY: ghcr.io
+  INSTALLER_IMAGE_NAME: ${{ github.repository }}-installer
+  MANAGER_IMAGE_NAME: ${{ github.repository }}-manager
+
+jobs:
+  update-manifests:
+    name: Update Manifests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Split branch name
+        env:
+          BRANCH: ${{ github.ref_name }}
+        id: split
+        run: echo "::set-output name=fragment::${BRANCH##*/}"
+
+      - name: Update Deployment Image Tags
+        working-directory: "config/production"
+        run: |
+          kustomize edit set image installer=${{ env.REGISTRY }}/${{ env.INSTALLER_IMAGE_NAME }}:${{ steps.split.outputs.fragment }}
+          kustomize edit set image manager=${{ env.REGISTRY }}/${{ env.MANAGER_IMAGE_NAME }}:${{ steps.split.outputs.fragment }}
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v6
+        with:
+          commit-message: "chore: update image versions"
+          title: "Update image versions"
+          base: main
+          branch: ${{ steps.split.outputs.fragment }}


### PR DESCRIPTION
This changes the release process a bit. Instead of pushing a tag and then committing image version updates with a commit after the tag, the image version changes are done with the same commit as the tag. This makes it possible to checkout a tag and modify the deployment manifests while having the correct version set on the images. The process will be as follows:

* git checkout -b release/v0.4.0 && git push
* action updates and commits the image versions
* action creates a PR with the version changes
* after merge, commit can be tagged and pushed