### PR TITLE
fix: improve handling on scaledown failure

### DIFF
--- a/zeropod/container.go
+++ b/zeropod/container.go
@@ -138,10 +138,10 @@ func (c *Container) scheduleScaleDownIn(in time.Duration) error {
 		log.G(c.context).Info("scaling down after scale down duration is up")
 
 		if err := c.scaleDown(c.context); err != nil {
-			// checkpointing failed, this is currently unrecoverable, so we
-			// shutdown our shim and let containerd recreate it.
-			log.G(c.context).Fatalf("scale down failed: %s", err)
-			os.Exit(1)
+			// checkpointing failed, this is currently unrecoverable. We set our
+			// initialProcess as exited to make sure it's restarted
+			log.G(c.context).Errorf("scale down failed: %s", err)
+			c.initialProcess.SetExited(1)
 		}
 
 	})


### PR DESCRIPTION
Instead of exiting our shim, we just set our initialProcess as exited so it will be killed and restarted by CRI. This is way cleaner since we don't leave orphan socket files laying around.