### PR TITLE
fix: runtime already configured on containerd v1

### DIFF
--- a/cmd/installer/main_test.go
+++ b/cmd/installer/main_test.go
@@ -90,7 +90,7 @@ imports = [
   "runtime_zeropod.toml",
 ]
 `
-	containerdv1AlreadyConfigured = runtimeConfig + `
+	containerdv1AlreadyConfigured = fullContainerdConfigV2 + runtimeConfig + `
 [plugins."io.containerd.internal.v1.opt"]
   path = "/opt/zeropod"
 `


### PR DESCRIPTION
with the new installer, the detection if the runtime is already installed when using containerd v1 broke. This fixes the issue by using a simpler string check instead of parsing/looking up the toml key.