### PR TITLE
fix: tracker cleanup

### DIFF
--- a/shim/container.go
+++ b/shim/container.go
@@ -264,6 +264,9 @@ func (c *Container) DeleteCheckpointedPID(pid int) {
 
 func (c *Container) Stop(ctx context.Context) {
 	c.CancelScaleDown()
+	if err := c.tracker.RemovePid(uint32(c.process.Pid())); err != nil {
+		log.G(ctx).Errorf("unable to remove pid from tracker: %s", err)
+	}
 	if err := c.tracker.Close(); err != nil {
 		log.G(ctx).Errorf("unable to close tracker: %s", err)
 	}

--- a/socket/host_resolver.go
+++ b/socket/host_resolver.go
@@ -26,9 +26,10 @@ func (h hostResolver) Resolve(pid uint32) uint32 {
 
 // findHostPid greps through the procfs to find the host pid of the supplied
 // namespaced pid. It's very ugly but it works well enough for testing with
-// Kind.
+// Kind. It would be better to use the procfs package here but NSpid is always
+// empty.
 func findHostPid(procPath string, nsPid uint32) (uint32, error) {
-	out, err := exec.Command("bash", "-c", fmt.Sprintf("grep %d -ril %s*/status | head -n 1", nsPid, procPath)).Output()
+	out, err := exec.Command("bash", "-c", fmt.Sprintf(`grep -P 'NSpid:.*\t%d\t' -ril %s*/status | head -n 1`, nsPid, procPath)).Output()
 	if err != nil {
 		return 0, err
 	}


### PR DESCRIPTION
The tracker pid was always not removed from the bpf map. The second commit improves the e2e test reliability of the tracker.