### PR TITLE
fix: check activator exists before calling stop

### DIFF
--- a/shim/container.go
+++ b/shim/container.go
@@ -237,7 +237,9 @@ func (c *Container) InitialProcess() process.Process {
 }
 
 func (c *Container) StopActivator(ctx context.Context) {
-	c.activator.Stop(ctx)
+	if c.activator != nil {
+		c.activator.Stop(ctx)
+	}
 }
 
 // CheckpointedPID indicates if the pid has been checkpointed before.


### PR DESCRIPTION
When the activator fails to initialize it can be `nil`. As it still triggers `Stop` when erroring the init, it ends up crashing during stop.