### PR TITLE
fix: store container create options for restore

### DIFF
--- a/shim/restore.go
+++ b/shim/restore.go
@@ -59,6 +59,7 @@ func (c *Container) Restore(ctx context.Context) (*runc.Container, process.Proce
 
 	createReq := &task.CreateTaskRequest{
 		ID:               c.ID(),
+		Options:          c.createOpts,
 		Bundle:           c.Bundle,
 		Terminal:         false,
 		Stdin:            c.initialProcess.Stdio().Stdin,

--- a/shim/task/service_zeropod.go
+++ b/shim/task/service_zeropod.go
@@ -136,7 +136,7 @@ func (w *wrapper) Create(ctx context.Context, r *taskAPI.CreateTaskRequest) (_ *
 		return w.service.Create(ctx, r)
 	}
 
-	zeropodContainer, err := zshim.New(w.context, cfg, r.ID, &w.checkpointRestore, w.platform, w.zeropodEvents)
+	zeropodContainer, err := zshim.New(w.context, cfg, r, &w.checkpointRestore, w.platform, w.zeropodEvents)
 	if err != nil {
 		return nil, fmt.Errorf("error creating scaled container: %w", err)
 	}


### PR DESCRIPTION
The initial create options that are passed from containerd were not stored, meaning some options got lost when restoring a zeropod. This resulted in the cgroups changing on restore as the systemd-cgroup option was not passed to runc anymore.

#65