### PR TITLE
feat: emit warnings when eBPF support is missing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,7 +81,7 @@ docker-bench: build-test
 # has to have SYS_ADMIN because the test tries to set netns and mount bpffs
 # we use --pid=host to make the ebpf tracker work without a pid resolver
 docker-test:
-	docker run --rm --cap-add=SYS_ADMIN --cap-add=NET_ADMIN --pid=host -v $(PWD):/app $(TEST_IMAGE) make test
+	docker run --rm --cap-add=SYS_ADMIN --cap-add=NET_ADMIN --pid=host --userns=host -v $(PWD):/app $(TEST_IMAGE) make test
 
 CLANG ?= clang
 CFLAGS := -O2 -g -Wall -Werror

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -47,14 +47,13 @@ func main() {
 	defer stop()
 
 	if err := manager.AttachRedirectors(ctx, log); err != nil {
-		log.Error("attaching redirectors", "err", err)
-		os.Exit(1)
+		log.Warn("attaching redirectors failed: restoring containers on traffic is disabled", "err", err)
 	}
 
 	cleanSocketTracker, err := socket.LoadEBPFTracker()
 	if err != nil {
-		log.Error("loading socket tracker", "err", err)
-		os.Exit(1)
+		log.Warn("loading socket tracker failed, scaling down with static duration", "err", err)
+		cleanSocketTracker = func() error { return nil }
 	}
 
 	mgr, err := newControllerManager()

--- a/e2e/Dockerfile
+++ b/e2e/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker:24.0-cli
+FROM docker:28.0-cli
 
 RUN apk add --update go make iptables
 WORKDIR /app

--- a/socket/tracker_test.go
+++ b/socket/tracker_test.go
@@ -16,7 +16,6 @@ import (
 // an HTTP server and doing a request against it. This test requires elevated
 // privileges to run.
 func TestEBPFTracker(t *testing.T) {
-	require.NoError(t, activator.MountDebugFS())
 	require.NoError(t, activator.MountBPFFS(activator.BPFFSPath))
 
 	clean, err := LoadEBPFTracker()


### PR DESCRIPTION
Instead of erroring out when eBPF support is missing, we just emit warnings and disable scale down support in the shim.

Fixes #59