### PR TITLE
feat: implement migrating upper container layer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,12 +11,12 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: "1.23"
+          go-version: "1.24"
 
-      - uses: dominikh/staticcheck-action@v1.3.1
+      - uses: dominikh/staticcheck-action@v1.4.0
         with:
           install-go: false
-          version: "2024.1"
+          version: "2025.1"
 
   test:
     runs-on: ${{ matrix.os }}
@@ -29,7 +29,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: "1.23"
+          go-version: "1.24"
 
       - name: test
         run: sudo --preserve-env make test
@@ -47,7 +47,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: "1.23"
+          go-version: "1.24"
 
       - name: Install protoc-gen-go
         run: |
@@ -84,7 +84,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: "1.23"
+          go-version: "1.24"
 
       - name: e2e
         run: make test-e2e

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ the last TCP connection. While in scaled down state, it will listen on the same
 port the application inside the container was listening on and will restore the
 container on the first incoming connection. Depending on the memory size of the
 checkpointed program this happens in tens to a few hundred milliseconds,
-virtually unnoticable to the user. As all the memory contents are stored to disk
+virtually unnoticeable to the user. As all the memory contents are stored to disk
 during checkpointing, all state of the application is restored. [It adjusts
 resource requests](#in-place-resource-scaling) in scaled down state in-place if
 the cluster supports it. To prevent huge resource usage spikes when draining a
@@ -283,7 +283,7 @@ zeropod.ctrox.dev/ports-map: "nginx=80,81;sidecar=8080"
 ### `zeropod.ctrox.dev/scaledown-duration`
 
 Configures how long to wait before scaling down again after the last
-connnection. The duration is reset whenever a connection happens. Setting it to
+connection. The duration is reset whenever a connection happens. Setting it to
 0 disables scaling down. If unset it defaults to 1 minute.
 
 ```yaml
@@ -352,6 +352,17 @@ to be enabled in the host kernel (`CONFIG_USERFAULTFD`).
 
 ```yaml
 zeropod.ctrox.dev/live-migrate: "nginx"
+```
+
+### `zeropod.ctrox.dev/disable-migrate-data`
+
+When migrating a pod (regardless of live or scaled down), data that has been
+written to the containers file system will be copied over. This is done by
+copying the upper layer of the container overlayfs. Enabled by default but can
+be disabled with this annotation.
+
+```yaml
+zeropod.ctrox.dev/disable-migrate-data: "true"
 ```
 
 ### `io.containerd.runc.v2.group`

--- a/api/node/v1/meta.go
+++ b/api/node/v1/meta.go
@@ -8,6 +8,7 @@ const (
 	SocketPath               = runPath + "node.sock"
 	imagesPath               = varPath + "i/"
 	SnapshotSuffix           = "snapshot"
+	UpperSuffix              = "upper"
 	WorkDirSuffix            = "work"
 	MigrateAnnotationKey     = "zeropod.ctrox.dev/migrate"
 	LiveMigrateAnnotationKey = "zeropod.ctrox.dev/live-migrate"
@@ -26,6 +27,10 @@ func WorkDirPath(id string) string {
 
 func SnapshotPath(id string) string {
 	return filepath.Join(ImagePath(id), SnapshotSuffix)
+}
+
+func UpperPath(id string) string {
+	return filepath.Join(ImagePath(id), SnapshotSuffix, UpperSuffix)
 }
 
 func LazyPagesSocket(id string) string {

--- a/cmd/freezer/Dockerfile
+++ b/cmd/freezer/Dockerfile
@@ -10,6 +10,6 @@ COPY cmd/freezer cmd/freezer
 ARG TARGETARCH
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=$TARGETARCH GO111MODULE=on go build -ldflags "-s -w" -a -o freezer cmd/freezer/main.go
 
-FROM gcr.io/distroless/static-debian12
+FROM gcr.io/distroless/static-debian12:debug
 COPY --from=builder /workspace/freezer /
 ENTRYPOINT ["/freezer"]

--- a/cmd/installer/main.go
+++ b/cmd/installer/main.go
@@ -86,6 +86,7 @@ network-lock skip
     "zeropod.ctrox.dev/live-migrate",
     "zeropod.ctrox.dev/disable-probe-detection",
     "zeropod.ctrox.dev/probe-buffer-size",
+    "zeropod.ctrox.dev/disable-migrate-data",
     "io.containerd.runc.v2.group"
   ]
 
@@ -108,6 +109,7 @@ network-lock skip
     "zeropod.ctrox.dev/live-migrate",
     "zeropod.ctrox.dev/disable-probe-detection",
     "zeropod.ctrox.dev/probe-buffer-size",
+    "zeropod.ctrox.dev/disable-migrate-data",
     "io.containerd.runc.v2.group"
   ]
 

--- a/cmd/manager/Dockerfile
+++ b/cmd/manager/Dockerfile
@@ -1,5 +1,5 @@
 ARG CRIU_IMAGE_NAME=ghcr.io/ctrox/zeropod-criu
-ARG CRIU_VERSION=v4.0
+ARG CRIU_VERSION=v4.1
 
 FROM --platform=$BUILDPLATFORM golang:1.24 AS builder
 

--- a/e2e/Dockerfile
+++ b/e2e/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker:28.0-cli
+FROM docker:28.3.3-cli
 
 RUN apk add --update go make iptables
 WORKDIR /app

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ctrox/zeropod
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/checkpoint-restore/go-criu/v7 v7.2.0

--- a/shim/config.go
+++ b/shim/config.go
@@ -25,6 +25,7 @@ const (
 	LiveMigrateAnnotationKey         = "zeropod.ctrox.dev/live-migrate"
 	DisableProbeDetectAnnotationKey  = "zeropod.ctrox.dev/disable-probe-detection"
 	ProbeBufferSizeAnnotationKey     = "zeropod.ctrox.dev/probe-buffer-size"
+	DisableMigrateDataAnnotationKey  = "zeropod.ctrox.dev/disable-migrate-data"
 	CRIContainerNameAnnotation       = "io.kubernetes.cri.container-name"
 	CRIContainerTypeAnnotation       = "io.kubernetes.cri.container-type"
 	CRIPodNameAnnotation             = "io.kubernetes.cri.sandbox-name"
@@ -55,6 +56,7 @@ type Config struct {
 	ContainerdNamespace   string
 	DisableProbeDetection bool
 	ProbeBufferSize       int
+	DisableMigrateData    bool
 	spec                  *specs.Spec
 }
 
@@ -157,6 +159,15 @@ func NewConfig(ctx context.Context, spec *specs.Spec) (*Config, error) {
 		}
 	}
 
+	disableMigrateDataValue := spec.Annotations[DisableMigrateDataAnnotationKey]
+	disableMigrateData := false
+	if disableMigrateDataValue != "" {
+		disableMigrateData, err = strconv.ParseBool(disableMigrateDataValue)
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	return &Config{
 		Ports:                 containerPorts,
 		ScaleDownDuration:     dur,
@@ -173,6 +184,7 @@ func NewConfig(ctx context.Context, spec *specs.Spec) (*Config, error) {
 		ContainerdNamespace:   ns,
 		DisableProbeDetection: disableProbeDetection,
 		ProbeBufferSize:       probeBufferSize,
+		DisableMigrateData:    disableMigrateData,
 		spec:                  spec,
 	}, nil
 }

--- a/socket/Dockerfile
+++ b/socket/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.23 as gomod
+FROM golang:1.24 as gomod
 
 WORKDIR /app
 ADD go.* /app


### PR DESCRIPTION
This is a very basic implementation of migrating the containers ephemeral storage during migration. It only supports the overlay snapshotter. It simply finds the upper layer by looking at /proc/*/mounts and then renames all paths in the upper layer into the snapshot directory before evac. On restore we do the reverse. This works okay for a first iteration but there may be many edge-cases and potential performance improvements. Especially the image pulling over TTRPC could be improved.