### PR TITLE
fix: skip in-flight TCP for runc 1.3.0+

### DIFF
--- a/shim/checkpoint_test.go
+++ b/shim/checkpoint_test.go
@@ -1,0 +1,28 @@
+package shim
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCheckpointExtraArgs(t *testing.T) {
+	for version, tc := range map[string]struct {
+		expectedArgs []string
+	}{
+		"":        {expectedArgs: []string{}},
+		"invalid": {expectedArgs: []string{}},
+		"1.0.0":   {expectedArgs: []string{}},
+		"1.2.0":   {expectedArgs: []string{}},
+		"1.2.6":   {expectedArgs: []string{}},
+		"1.3.0":   {expectedArgs: []string{checkpointArgSkipTCPInFlight}},
+		"1.3.3":   {expectedArgs: []string{checkpointArgSkipTCPInFlight}},
+		"1.4.4":   {expectedArgs: []string{checkpointArgSkipTCPInFlight}},
+		"2.0.4":   {expectedArgs: []string{checkpointArgSkipTCPInFlight}},
+	} {
+		t.Run(version, func(t *testing.T) {
+			c := Container{runcVersion: version}
+			assert.Equal(t, tc.expectedArgs, c.checkpointExtraArgs())
+		})
+	}
+}

--- a/shim/evac.go
+++ b/shim/evac.go
@@ -106,7 +106,7 @@ func (c *Container) evac(ctx context.Context) error {
 			checkpointCtx, c.ID(), &runcC.CheckpointOpts{
 				ImagePath:                nodev1.SnapshotPath(c.ID()),
 				CriuPageServer:           fmt.Sprintf("%s:12345", nodev1.LazyPagesSocket(c.ID())),
-				AllowOpenTCP:             true,
+				AllowOpenTCP:             false,
 				AllowExternalUnixSockets: true,
 				AllowTerminal:            false,
 				FileLocks:                true,
@@ -114,6 +114,7 @@ func (c *Container) evac(ctx context.Context) error {
 				WorkDir:                  nodev1.WorkDirPath(c.ID()),
 				LazyPages:                true,
 				StatusFile:               statusWrite,
+				ExtraArgs:                c.checkpointExtraArgs(),
 			}); err != nil {
 			errChan <- err
 			return


### PR DESCRIPTION
With runc 1.3.0 they added the criu flag --tcp-skip-in-flight to the checkpoint command, which means the default has changed and the flag takes precedence over the config where we already set skip-in-flight. So we now add the flag to the runc extraArgs if we detect 1.3.0+.