### PR TITLE
claim migration as soon as possible

### DIFF
--- a/activator/activator.go
+++ b/activator/activator.go
@@ -102,6 +102,9 @@ func (s *Server) Started() bool {
 }
 
 func (s *Server) Reset() error {
+	if !s.Started() {
+		return nil
+	}
 	for _, port := range s.ports {
 		if err := s.enableRedirect(port); err != nil {
 			return err
@@ -111,6 +114,9 @@ func (s *Server) Reset() error {
 }
 
 func (s *Server) DisableRedirects() error {
+	if !s.Started() {
+		return nil
+	}
 	for _, port := range s.ports {
 		if err := s.disableRedirect(port); err != nil {
 			return err

--- a/api/runtime/v1/types.go
+++ b/api/runtime/v1/types.go
@@ -23,6 +23,9 @@ type MigrationSpec struct {
 	// pages, which might result in a slower migration.
 	// +optional
 	LiveMigration bool `json:"liveMigration"`
+	// RestoreReady indicates the shim is up and running and is ready to restore
+	// so checkpointing can be started on the other side.
+	RestoreReady bool `json:"restoreReady"`
 	// SourceNode of the pod to be migrated
 	SourceNode string `json:"sourceNode"`
 	// TargetNode of the pod to be migrated

--- a/api/runtime/v1/types.go
+++ b/api/runtime/v1/types.go
@@ -3,6 +3,8 @@ package v1
 import (
 	"fmt"
 
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -115,4 +117,26 @@ type MigrationList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`
 	Items           []Migration `json:"items"`
+}
+
+// MatchesPod checks if the migration would be a match for this pod.
+func (mig Migration) MatchesPod(pod *corev1.Pod) bool {
+	return mig.Spec.PodTemplateHash == pod.Labels[appsv1.DefaultDeploymentUniqueLabelKey]
+}
+
+// Claim sets the target pod and node to claim the migration
+func (mig *Migration) Claim(targetPodName, targetNodeName string) {
+	mig.Spec.TargetPod = targetPodName
+	mig.Spec.TargetNode = targetNodeName
+}
+
+// ClaimedAndMatchesPod indicates the migration has been claimed and targets our
+// pod.
+func (mig Migration) ClaimedAndMatchesPod(pod *corev1.Pod) bool {
+	return mig.Spec.TargetPod == pod.Name && mig.Claimed()
+}
+
+// Claimed indicates if this migration already has been claimed
+func (mig Migration) Claimed() bool {
+	return mig.Spec.TargetNode != ""
 }

--- a/config/crds/runtime.zeropod.ctrox.dev_migrations.yaml
+++ b/config/crds/runtime.zeropod.ctrox.dev_migrations.yaml
@@ -107,6 +107,11 @@ spec:
                   PodTemplateHash of the source pod. This is used to find a suitable target
                   pod.
                 type: string
+              restoreReady:
+                description: |-
+                  RestoreReady indicates the shim is up and running and is ready to restore
+                  so checkpointing can be started on the other side.
+                type: boolean
               sourceNode:
                 description: SourceNode of the pod to be migrated
                 type: string
@@ -122,6 +127,7 @@ spec:
             required:
             - containers
             - podTemplateHash
+            - restoreReady
             - sourceNode
             type: object
           status:


### PR DESCRIPTION
We now try to claim a migration as quickly as possible after the new pod has been scheduled. The migration can still be claimed by the node service if the controller failed to do so for whatever reason but in the most cases the controller will be earlier so a migration can be claimed before things like image pulling has been completed.

Closes #97