### PR TITLE
fix: prevent liveness probes from preventing scaling to zero

### DIFF
--- a/shim/container.go
+++ b/shim/container.go
@@ -218,6 +218,10 @@ func (c *Container) setPhaseNotify(phase v1.ContainerPhase, duration time.Durati
 	c.sendEvent(c.Status())
 }
 
+func (c *Container) setScaledDownFlag(flag bool) {
+	c.scaledDown = flag
+}
+
 func (c *Container) SetSkipStart(skip bool) {
 	c.skipStart = skip
 }


### PR DESCRIPTION
fixes #86 . The shim now flips its scaledDown flag before calling CRIU