### PR TITLE
test: disable pinning

### DIFF
--- a/activator/activator_test.go
+++ b/activator/activator_test.go
@@ -149,6 +149,9 @@ func TestActivator(t *testing.T) {
 					map[string]uint32{SocketTrackerMap: 1024},
 				),
 				TrackerIgnoreLocalhost(tc.trackerIgnoreLocalhost),
+				// disable pinning for this test since this is flaky on some
+				// systems (gh actions mostly)
+				DisablePinning(),
 			)
 			require.NoError(t, err)
 			require.NoError(t, bpf.AttachRedirector("lo"))


### PR DESCRIPTION
the activator test became flaky on github actions since pinning was enabled so disable it in the test for now as this is not reproducible outside of actions.