### PR TITLE
feat: remove global checkpoint lock

### DIFF
--- a/shim/checkpoint.go
+++ b/shim/checkpoint.go
@@ -40,8 +40,8 @@ func (c *Container) scaleDown(ctx context.Context) error {
 }
 
 func (c *Container) kill(ctx context.Context) error {
-	c.checkpointRestore.Lock()
-	defer c.checkpointRestore.Unlock()
+	c.CheckpointRestore.Lock()
+	defer c.CheckpointRestore.Unlock()
 	log.G(ctx).Infof("checkpointing is disabled, scaling down by killing")
 	c.AddCheckpointedPID(c.Pid())
 
@@ -53,8 +53,8 @@ func (c *Container) kill(ctx context.Context) error {
 }
 
 func (c *Container) checkpoint(ctx context.Context) error {
-	c.checkpointRestore.Lock()
-	defer c.checkpointRestore.Unlock()
+	c.CheckpointRestore.Lock()
+	defer c.CheckpointRestore.Unlock()
 
 	snapshotDir := nodev1.SnapshotPath(c.ID())
 	if err := os.RemoveAll(snapshotDir); err != nil {

--- a/shim/restore.go
+++ b/shim/restore.go
@@ -34,8 +34,8 @@ var (
 )
 
 func (c *Container) Restore(ctx context.Context) (*runc.Container, process.Process, error) {
-	c.checkpointRestore.Lock()
-	defer c.checkpointRestore.Unlock()
+	c.CheckpointRestore.Lock()
+	defer c.CheckpointRestore.Unlock()
 	if !c.ScaledDown() {
 		return nil, nil, ErrAlreadyRestored
 	}


### PR DESCRIPTION
instead of locking globally per shim service, checkpoint/restore locking per container makes more sense and should not cause issues anymore. Especially when using grouping, locking per shim is causing lots of slowdowns.