### PR TITLE
fix: do not clean pin path on activator stop

### DIFF
--- a/activator/activator.go
+++ b/activator/activator.go
@@ -207,11 +207,6 @@ func (s *Server) Stop(ctx context.Context) {
 		log.G(ctx).WithError(err).Error("closing bpf maps")
 	}
 
-	log.G(ctx).Debugf("removing %s", PinPath(s.sandboxPid))
-	if err := cleanPinPath(s.sandboxPid); err != nil {
-		log.G(ctx).WithError(err).Error("cleaning pin path")
-	}
-
 	s.wg.Wait()
 	log.G(ctx).Debug("activator stopped")
 }

--- a/activator/bpf.go
+++ b/activator/bpf.go
@@ -231,11 +231,11 @@ func (bpf *BPF) Cleanup() error {
 	}
 
 	bpf.log.Info("deleting", "path", PinPath(bpf.pid))
-	errs = append(errs, cleanPinPath(bpf.pid))
+	errs = append(errs, CleanPinPath(bpf.pid))
 	return errors.Join(errs...)
 }
 
-func cleanPinPath(pid int) error {
+func CleanPinPath(pid int) error {
 	return errors.Join(
 		os.RemoveAll(PinPath(pid)),
 		os.RemoveAll(PinPath(pid)+ManagedByShimSuffix),

--- a/shim/task/service_zeropod.go
+++ b/shim/task/service_zeropod.go
@@ -24,6 +24,7 @@ import (
 	"github.com/containerd/ttrpc"
 
 	"github.com/containerd/typeurl/v2"
+	"github.com/ctrox/zeropod/activator"
 	v1 "github.com/ctrox/zeropod/api/shim/v1"
 	zshim "github.com/ctrox/zeropod/shim"
 	"google.golang.org/protobuf/types/known/emptypb"
@@ -296,6 +297,9 @@ func (w *wrapper) Delete(ctx context.Context, r *taskAPI.DeleteRequest) (*taskAP
 	log.G(ctx).Info("delete called")
 	zeropodContainer, ok := w.getZeropodContainer(r.ID)
 	if !ok {
+		if err := w.cleanSandboxPin(ctx, r); err != nil {
+			log.G(ctx).WithError(err).Error("cleaning up sandbox pin")
+		}
 		return w.service.Delete(ctx, r)
 	}
 	log.G(ctx).Infof("delete called in zeropod: %s", zeropodContainer.ID())
@@ -464,4 +468,30 @@ func (w *wrapper) postRestore(container *runc.Container, handleStarted zshim.Han
 	if handleStarted != nil {
 		handleStarted(container, p)
 	}
+}
+
+// cleanSandboxPin cleanes the eBPF pin path of the sandbox container.
+func (w *wrapper) cleanSandboxPin(ctx context.Context, r *taskAPI.DeleteRequest) error {
+	if r.ExecID != "" {
+		return nil
+	}
+	container, err := w.getContainer(r.ID)
+	if err != nil {
+		return err
+	}
+	spec, err := zshim.GetSpec(container.Bundle)
+	if err != nil {
+		return err
+	}
+	cfg, err := v1.NewConfig(ctx, spec)
+	if err != nil {
+		return err
+	}
+	if cfg.ContainerType != containerTypeSandbox {
+		return nil
+	}
+	if err := activator.CleanPinPath(container.Pid()); err != nil {
+		return err
+	}
+	return nil
 }


### PR DESCRIPTION
instead clean it only when the sandbox is deleted, e.g. mainly on pod removal.