### PR TITLE
fix: cleanup on checkpoint process exit

### DIFF
--- a/shim/task/service_zeropod.go
+++ b/shim/task/service_zeropod.go
@@ -413,10 +413,19 @@ func (w *wrapper) processExits() {
 				preventExit = true
 			}
 		}
-		if !preventExit {
-			// pass event to service exit channel
-			w.service.ec <- e
+		if preventExit {
+			// cleanup running and exec maps
+			w.lifecycleMu.Lock()
+			delete(w.running, e.Pid)
+			for _, cp := range cps {
+				delete(w.execCountSubscribers, cp.Container)
+				delete(w.runningExecs, cp.Container)
+			}
+			w.lifecycleMu.Unlock()
+			continue
 		}
+		// pass event to service exit channel
+		w.service.ec <- e
 	}
 }
 


### PR DESCRIPTION
When skipping to notify the exit channel we should still cleanup some of the maps the container service uses to keep track of running/exec containers.