### PR TITLE
feat: improve capacity eviction

### DIFF
--- a/api/node/v1/node.pb.go
+++ b/api/node/v1/node.pb.go
@@ -540,10 +540,11 @@ func (x *PullImageRequest) GetImageId() string {
 }
 
 type RestoreCapacityRequest struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	PodInfo       *PodInfo               `protobuf:"bytes,1,opt,name=pod_info,json=podInfo,proto3" json:"pod_info,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	state                 protoimpl.MessageState `protogen:"open.v1"`
+	PodInfo               *PodInfo               `protobuf:"bytes,1,opt,name=pod_info,json=podInfo,proto3" json:"pod_info,omitempty"`
+	CheckpointMemoryBytes uint64                 `protobuf:"varint,3,opt,name=checkpoint_memory_bytes,json=checkpointMemoryBytes,proto3" json:"checkpoint_memory_bytes,omitempty"`
+	unknownFields         protoimpl.UnknownFields
+	sizeCache             protoimpl.SizeCache
 }
 
 func (x *RestoreCapacityRequest) Reset() {
@@ -581,6 +582,13 @@ func (x *RestoreCapacityRequest) GetPodInfo() *PodInfo {
 		return x.PodInfo
 	}
 	return nil
+}
+
+func (x *RestoreCapacityRequest) GetCheckpointMemoryBytes() uint64 {
+	if x != nil {
+		return x.CheckpointMemoryBytes
+	}
+	return 0
 }
 
 type RestoreCapacityResponse struct {
@@ -675,9 +683,10 @@ const file_node_proto_rawDesc = "" +
 	"\x04port\x18\x03 \x01(\x05R\x04port\x12\x10\n" +
 	"\x03tls\x18\x04 \x01(\bR\x03tls\"-\n" +
 	"\x10PullImageRequest\x12\x19\n" +
-	"\bimage_id\x18\x01 \x01(\tR\aimageId\"M\n" +
+	"\bimage_id\x18\x01 \x01(\tR\aimageId\"\x85\x01\n" +
 	"\x16RestoreCapacityRequest\x123\n" +
-	"\bpod_info\x18\x01 \x01(\v2\x18.zeropod.node.v1.PodInfoR\apodInfo\"X\n" +
+	"\bpod_info\x18\x01 \x01(\v2\x18.zeropod.node.v1.PodInfoR\apodInfo\x126\n" +
+	"\x17checkpoint_memory_bytes\x18\x03 \x01(\x04R\x15checkpointMemoryBytes\"X\n" +
 	"\x17RestoreCapacityResponse\x12\x18\n" +
 	"\aallowed\x18\x01 \x01(\bR\aallowed\x12#\n" +
 	"\rredirect_addr\x18\x02 \x01(\tR\fredirectAddr2\xbc\x04\n" +

--- a/api/node/v1/node.proto
+++ b/api/node/v1/node.proto
@@ -70,6 +70,7 @@ message PullImageRequest {
 
 message RestoreCapacityRequest {
   PodInfo pod_info = 1;
+  uint64 checkpoint_memory_bytes = 3;
 }
 
 message RestoreCapacityResponse {

--- a/api/shim/v1/shim.pb.go
+++ b/api/shim/v1/shim.pb.go
@@ -367,6 +367,7 @@ type ContainerMetrics struct {
 	Running                bool                   `protobuf:"varint,8,opt,name=running,proto3" json:"running,omitempty"`
 	CheckpointErrors       int64                  `protobuf:"varint,9,opt,name=checkpoint_errors,json=checkpointErrors,proto3" json:"checkpoint_errors,omitempty"`
 	RestoreErrors          int64                  `protobuf:"varint,10,opt,name=restore_errors,json=restoreErrors,proto3" json:"restore_errors,omitempty"`
+	CheckpointMemoryBytes  uint64                 `protobuf:"varint,11,opt,name=checkpoint_memory_bytes,json=checkpointMemoryBytes,proto3" json:"checkpoint_memory_bytes,omitempty"`
 	unknownFields          protoimpl.UnknownFields
 	sizeCache              protoimpl.SizeCache
 }
@@ -471,6 +472,13 @@ func (x *ContainerMetrics) GetRestoreErrors() int64 {
 	return 0
 }
 
+func (x *ContainerMetrics) GetCheckpointMemoryBytes() uint64 {
+	if x != nil {
+		return x.CheckpointMemoryBytes
+	}
+	return 0
+}
+
 var File_shim_proto protoreflect.FileDescriptor
 
 const file_shim_proto_rawDesc = "" +
@@ -494,7 +502,7 @@ const file_shim_proto_rawDesc = "" +
 	"\n" +
 	"event_time\x18\x06 \x01(\v2\x1a.google.protobuf.TimestampR\teventTime\x12@\n" +
 	"\x0eevent_duration\x18\a \x01(\v2\x19.google.protobuf.DurationR\reventDuration\x12\x1b\n" +
-	"\tevent_log\x18\b \x01(\tR\beventLog\"\xf6\x03\n" +
+	"\tevent_log\x18\b \x01(\tR\beventLog\"\xae\x04\n" +
 	"\x10ContainerMetrics\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x19\n" +
 	"\bpod_name\x18\x02 \x01(\tR\apodName\x12#\n" +
@@ -506,7 +514,8 @@ const file_shim_proto_rawDesc = "" +
 	"\arunning\x18\b \x01(\bR\arunning\x12+\n" +
 	"\x11checkpoint_errors\x18\t \x01(\x03R\x10checkpointErrors\x12%\n" +
 	"\x0erestore_errors\x18\n" +
-	" \x01(\x03R\rrestoreErrors*g\n" +
+	" \x01(\x03R\rrestoreErrors\x126\n" +
+	"\x17checkpoint_memory_bytes\x18\v \x01(\x04R\x15checkpointMemoryBytes*g\n" +
 	"\x0eContainerPhase\x12\x0f\n" +
 	"\vSCALED_DOWN\x10\x00\x12\v\n" +
 	"\aRUNNING\x10\x01\x12\f\n" +

--- a/api/shim/v1/shim.proto
+++ b/api/shim/v1/shim.proto
@@ -59,4 +59,5 @@ message ContainerMetrics {
     bool running = 8;
     int64 checkpoint_errors = 9;
     int64 restore_errors = 10;
+    uint64 checkpoint_memory_bytes = 11;
 }

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -55,7 +55,9 @@ var (
 	migrationReadyTimeout   = flag.Duration("migration-ready-timeout", time.Minute*5, "how long to wait for migration to be ready")
 	evictionTimeout         = flag.Duration("eviction-timeout", time.Minute, "how long to wait for eviction")
 	autoGCMigrations        = flag.Bool("auto-gc-migrations", true, "automatically garbage collect migrations when owning pod is deleted")
-	capacitySystemMemory    = flag.Bool("capacity-system-memory", false, "use system memory instead of pod requests for capacity tracking")
+
+	capacityEvictionThreshold = flag.Float64("capacity-eviction-threshold", 1.0, "the threshold when capacity eviction starts. Can be above 1.0 for overprovisioning.")
+	capacitySystemMemory      = flag.Bool("capacity-system-memory", false, "use system memory instead of pod requests for capacity tracking")
 
 	version   = ""
 	revision  = ""
@@ -170,9 +172,9 @@ func main() {
 
 	var cap capacity.Tracker
 	if *capacitySystemMemory {
-		cap = capacity.NewSystemMemoryTracker(registry, nodeName)
+		cap = capacity.NewSystemMemoryTracker(registry, nodeName, *capacityEvictionThreshold)
 	} else {
-		cap = capacity.NewNodeTracker(registry, nodeName)
+		cap = capacity.NewNodeTracker(registry, nodeName, *capacityEvictionThreshold)
 	}
 	nodeServer, err := node.NewServer(
 		*nodeServerAddr,

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -55,6 +55,7 @@ var (
 	migrationReadyTimeout   = flag.Duration("migration-ready-timeout", time.Minute*5, "how long to wait for migration to be ready")
 	evictionTimeout         = flag.Duration("eviction-timeout", time.Minute, "how long to wait for eviction")
 	autoGCMigrations        = flag.Bool("auto-gc-migrations", true, "automatically garbage collect migrations when owning pod is deleted")
+	capacitySystemMemory    = flag.Bool("capacity-system-memory", false, "use system memory instead of pod requests for capacity tracking")
 
 	version   = ""
 	revision  = ""
@@ -167,7 +168,12 @@ func main() {
 		}
 	}()
 
-	cap := capacity.NewNodeTracker(registry, nodeName)
+	var cap capacity.Tracker
+	if *capacitySystemMemory {
+		cap = capacity.NewSystemMemoryTracker(registry, nodeName)
+	} else {
+		cap = capacity.NewNodeTracker(registry, nodeName)
+	}
 	nodeServer, err := node.NewServer(
 		*nodeServerAddr,
 		mgr.GetClient(),

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -27,6 +27,9 @@ zeropod_running{container="nginx",namespace="default",pod="nginx"} 0
 # HELP zeropod_checkpoint_errors_total Total number of checkpoint errors.
 # TYPE zeropod_checkpoint_errors_total counter
 zeropod_checkpoint_errors_total{container="nginx",namespace="default",pod="nginx"} 0
+# HELP zeropod_checkpoint_memory_bytes Memory pages dumped by criu in bytes.
+# TYPE zeropod_checkpoint_memory_bytes gauge
+zeropod_checkpoint_memory_bytes{container="nginx",namespace="default",pod="nginx"} 5.1257344e+07
 # HELP zeropod_restore_errors_total Total number of restore errors.
 # TYPE zeropod_restore_errors_total counter
 zeropod_restore_errors_total{container="nginx",namespace="default",pod="nginx"} 0

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -478,13 +478,17 @@ func TestE2E(t *testing.T) {
 			},
 			"checkpoint errors": {
 				metric:       prometheus.BuildFQName(manager.MetricsNamespace, "", manager.MetricCheckpointErrorsTotal),
-				pod:          restoredPod,
+				pod:          checkpointedPod,
 				counterValue: new(float64(0)),
 			},
 			"restore errors": {
 				metric:       prometheus.BuildFQName(manager.MetricsNamespace, "", manager.MetricRestoreErrorsTotal),
 				pod:          restoredPod,
 				counterValue: new(float64(0)),
+			},
+			"checkpoint memory": {
+				metric: prometheus.BuildFQName(manager.MetricsNamespace, "", manager.MetricCheckpointMemoryBytes),
+				pod:    checkpointedPod,
 			},
 		}
 

--- a/manager/capacity/capacity.go
+++ b/manager/capacity/capacity.go
@@ -32,6 +32,7 @@ type Tracker interface {
 	SetCapacity(name corev1.ResourceName, q resource.Quantity)
 	SetRequested(name corev1.ResourceName, q resource.Quantity)
 	IncEvicted()
+	UseCheckpointMemory() bool
 }
 
 type NodeTracker struct {
@@ -80,6 +81,10 @@ func (c *NodeTracker) SetRequested(name corev1.ResourceName, q resource.Quantity
 
 func (c *NodeTracker) IncEvicted() {
 	c.metrics.evicted.With(prometheus.Labels{labelNode: c.name}).Inc()
+}
+
+func (c *NodeTracker) UseCheckpointMemory() bool {
+	return false
 }
 
 func (c *NodeTracker) metricLabels(resource string) prometheus.Labels {

--- a/manager/capacity/capacity.go
+++ b/manager/capacity/capacity.go
@@ -31,6 +31,7 @@ type Tracker interface {
 	Requested(name corev1.ResourceName) resource.Quantity
 	SetCapacity(name corev1.ResourceName, q resource.Quantity)
 	SetRequested(name corev1.ResourceName, q resource.Quantity)
+	Threshold() float64
 	IncEvicted()
 	UseCheckpointMemory() bool
 }
@@ -39,6 +40,7 @@ type NodeTracker struct {
 	name      string
 	capacity  corev1.ResourceList
 	requested corev1.ResourceList
+	threshold float64
 	mu        sync.RWMutex
 	metrics   metrics
 }
@@ -83,6 +85,11 @@ func (c *NodeTracker) IncEvicted() {
 	c.metrics.evicted.With(prometheus.Labels{labelNode: c.name}).Inc()
 }
 
+// Threshold where capacity eviction starts.
+func (c *NodeTracker) Threshold() float64 {
+	return c.threshold
+}
+
 func (c *NodeTracker) UseCheckpointMemory() bool {
 	return false
 }
@@ -92,11 +99,12 @@ func (c *NodeTracker) metricLabels(resource string) prometheus.Labels {
 }
 
 // NewNodeTracker creates a [NodeTracker].
-func NewNodeTracker(reg prometheus.Registerer, name string) Tracker {
+func NewNodeTracker(reg prometheus.Registerer, name string, threshold float64) Tracker {
 	return &NodeTracker{
 		name:      name,
 		capacity:  corev1.ResourceList{},
 		requested: corev1.ResourceList{},
+		threshold: threshold,
 		mu:        sync.RWMutex{},
 		metrics: metrics{
 			capacity: promauto.With(reg).NewGaugeVec(prometheus.GaugeOpts{
@@ -153,4 +161,16 @@ func RemoveTaint(node *corev1.Node) {
 	node.Spec.Taints = slices.DeleteFunc(node.Spec.Taints, func(t corev1.Taint) bool {
 		return t.Key == TaintKey
 	})
+}
+
+// CmpThreshold returns 0 if requested is equal to capacity, -1 if the requested is less
+// than capacity, or 1 if the requested is greater than capacity. Note that
+// capacity will be multiplied by the [Tracker] threshold.
+func CmpThreshold(cap Tracker, name corev1.ResourceName, requested resource.Quantity) int {
+	return requested.Cmp(multiplyQuantity(cap.Capacity(name), cap.Threshold()))
+}
+
+func multiplyQuantity(q resource.Quantity, factor float64) resource.Quantity {
+	newMilli := int64(float64(q.MilliValue()) * factor)
+	return *resource.NewMilliQuantity(newMilli, q.Format)
 }

--- a/manager/capacity/capacity_test.go
+++ b/manager/capacity/capacity_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestNodeTracker(t *testing.T) {
-	tracker := NewNodeTracker(prometheus.NewRegistry(), "name")
+	tracker := NewNodeTracker(prometheus.NewRegistry(), "name", 1.0)
 	assert.Empty(t, tracker.Capacity(corev1.ResourceCPU))
 	assert.Empty(t, tracker.Capacity(corev1.ResourceMemory))
 	assert.Empty(t, tracker.Requested(corev1.ResourceCPU))

--- a/manager/capacity/noop.go
+++ b/manager/capacity/noop.go
@@ -30,6 +30,10 @@ func (n *NoopTracker) SetRequested(name corev1.ResourceName, q resource.Quantity
 func (n *NoopTracker) IncEvicted() {
 }
 
+func (n *NoopTracker) UseCheckpointMemory() bool {
+	return false
+}
+
 // NewNoopTracker creates a [NoopTracker]
 func NewNoopTracker() Tracker {
 	return &NoopTracker{}

--- a/manager/capacity/noop.go
+++ b/manager/capacity/noop.go
@@ -30,8 +30,14 @@ func (n *NoopTracker) SetRequested(name corev1.ResourceName, q resource.Quantity
 func (n *NoopTracker) IncEvicted() {
 }
 
+// UseCheckpointMemory implements [Tracker].
 func (n *NoopTracker) UseCheckpointMemory() bool {
 	return false
+}
+
+// Threshold implements [Tracker].
+func (n *NoopTracker) Threshold() float64 {
+	return 1.0
 }
 
 // NewNoopTracker creates a [NoopTracker]

--- a/manager/capacity/system_memory.go
+++ b/manager/capacity/system_memory.go
@@ -16,8 +16,8 @@ type SystemMemoryTracker struct {
 }
 
 // NewSystemMemoryTracker creates a [SystemMemoryTracker].
-func NewSystemMemoryTracker(reg prometheus.Registerer, name string) Tracker {
-	return &SystemMemoryTracker{Tracker: NewNodeTracker(reg, name)}
+func NewSystemMemoryTracker(reg prometheus.Registerer, name string, threshold float64) Tracker {
+	return &SystemMemoryTracker{Tracker: NewNodeTracker(reg, name, threshold)}
 }
 
 // Capacity gets the memory capacity from the total node memory.

--- a/manager/capacity/system_memory.go
+++ b/manager/capacity/system_memory.go
@@ -1,0 +1,125 @@
+package capacity
+
+import (
+	"bufio"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/prometheus/client_golang/prometheus"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+type SystemMemoryTracker struct {
+	Tracker
+}
+
+// NewSystemMemoryTracker creates a [SystemMemoryTracker].
+func NewSystemMemoryTracker(reg prometheus.Registerer, name string) Tracker {
+	return &SystemMemoryTracker{Tracker: NewNodeTracker(reg, name)}
+}
+
+// Capacity gets the memory capacity from the total node memory.
+func (m *SystemMemoryTracker) Capacity(name corev1.ResourceName) resource.Quantity {
+	if name == corev1.ResourceMemory {
+		return getTotalNodeMemory()
+	}
+	return m.Tracker.Capacity(name)
+}
+
+// Requested gets memory requests from the current available system memory.
+func (m *SystemMemoryTracker) Requested(name corev1.ResourceName) resource.Quantity {
+	if name == corev1.ResourceMemory {
+		return getCurrentNodeMemoryUsage()
+	}
+	return m.Tracker.Requested(name)
+}
+
+// SetCapacity sets the memory capacity to the total node memory.
+func (m *SystemMemoryTracker) SetCapacity(name corev1.ResourceName, q resource.Quantity) {
+	if name == corev1.ResourceMemory {
+		q = getTotalNodeMemory()
+	}
+	m.Tracker.SetCapacity(name, q)
+}
+
+// SetRequested sets memory requests to the current available system memory.
+func (m *SystemMemoryTracker) SetRequested(name corev1.ResourceName, q resource.Quantity) {
+	if name == corev1.ResourceMemory {
+		q = getCurrentNodeMemoryUsage()
+	}
+	m.Tracker.SetRequested(name, q)
+}
+
+func (m *SystemMemoryTracker) UseCheckpointMemory() bool {
+	return true
+}
+
+func getTotalNodeMemory() resource.Quantity {
+	memStats, err := sysMemoryStats()
+	if err != nil {
+		return resource.Quantity{}
+	}
+	return *resource.NewQuantity(int64(memStats.totalBytes), resource.BinarySI)
+}
+
+func getCurrentNodeMemoryUsage() resource.Quantity {
+	memStats, err := sysMemoryStats()
+	if err != nil {
+		return resource.Quantity{}
+	}
+	return *resource.NewQuantity(int64(memStats.usedBytes), resource.BinarySI)
+}
+
+type sysMemory struct {
+	totalBytes     uint64
+	availableBytes uint64
+	usedBytes      uint64
+}
+
+func sysMemoryStats() (*sysMemory, error) {
+	file, err := os.Open("/proc/meminfo")
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+
+	var memTotal, memAvailable uint64
+	scanner := bufio.NewScanner(file)
+
+	for scanner.Scan() {
+		line := scanner.Text()
+		fields := strings.Fields(line)
+		if len(fields) < 2 {
+			continue
+		}
+
+		key := strings.TrimSuffix(fields[0], ":")
+		val, err := strconv.ParseUint(fields[1], 10, 64)
+		if err != nil {
+			continue
+		}
+
+		switch key {
+		case "MemTotal":
+			memTotal = val * 1024
+		case "MemAvailable":
+			memAvailable = val * 1024
+		}
+
+		if memTotal > 0 && memAvailable > 0 {
+			break
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+
+	return &sysMemory{
+		totalBytes:     memTotal,
+		availableBytes: memAvailable,
+		usedBytes:      memTotal - memAvailable,
+	}, nil
+}

--- a/manager/capacity/system_memory_test.go
+++ b/manager/capacity/system_memory_test.go
@@ -1,0 +1,31 @@
+package capacity
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+func TestSystemMemoryTracker(t *testing.T) {
+	tracker := NewSystemMemoryTracker(prometheus.NewRegistry(), "name")
+	assert.Empty(t, tracker.Capacity(corev1.ResourceCPU))
+	assert.NotEmpty(t, tracker.Capacity(corev1.ResourceMemory))
+	assert.Empty(t, tracker.Requested(corev1.ResourceCPU))
+	assert.NotEmpty(t, tracker.Requested(corev1.ResourceMemory))
+
+	// we expect the system memory to not equal 100Ti. In case that ever becomes
+	// real this test will fail but who can be mad about that!
+	cpu, memory := resource.MustParse("8"), resource.MustParse("100Ti")
+	tracker.SetCapacity(corev1.ResourceCPU, cpu)
+	tracker.SetCapacity(corev1.ResourceMemory, memory)
+	assert.Equal(t, cpu, tracker.Capacity(corev1.ResourceCPU))
+	assert.NotEqual(t, memory, tracker.Capacity(corev1.ResourceMemory))
+
+	tracker.SetRequested(corev1.ResourceCPU, cpu)
+	tracker.SetRequested(corev1.ResourceMemory, memory)
+	assert.Equal(t, cpu, tracker.Requested(corev1.ResourceCPU))
+	assert.NotEqual(t, memory, tracker.Requested(corev1.ResourceMemory))
+}

--- a/manager/capacity/system_memory_test.go
+++ b/manager/capacity/system_memory_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestSystemMemoryTracker(t *testing.T) {
-	tracker := NewSystemMemoryTracker(prometheus.NewRegistry(), "name")
+	tracker := NewSystemMemoryTracker(prometheus.NewRegistry(), "name", 1.0)
 	assert.Empty(t, tracker.Capacity(corev1.ResourceCPU))
 	assert.NotEmpty(t, tracker.Capacity(corev1.ResourceMemory))
 	assert.Empty(t, tracker.Requested(corev1.ResourceCPU))

--- a/manager/metrics_collector.go
+++ b/manager/metrics_collector.go
@@ -25,6 +25,7 @@ const (
 	MetricRunning               = "running"
 	MetricCheckpointErrorsTotal = "checkpoint_errors_total"
 	MetricRestoreErrorsTotal    = "restore_errors_total"
+	MetricCheckpointMemoryBytes = "checkpoint_memory_bytes"
 )
 
 var (
@@ -37,14 +38,15 @@ var (
 )
 
 type Collector struct {
-	log                *slog.Logger
-	checkpointDuration *prometheus.HistogramVec
-	restoreDuration    *prometheus.HistogramVec
-	lastCheckpointTime *prometheus.GaugeVec
-	lastRestoreTime    *prometheus.GaugeVec
-	running            *prometheus.GaugeVec
-	checkpointErrors   *prometheus.CounterVec
-	restoreErrors      *prometheus.CounterVec
+	log                   *slog.Logger
+	checkpointDuration    *prometheus.HistogramVec
+	restoreDuration       *prometheus.HistogramVec
+	lastCheckpointTime    *prometheus.GaugeVec
+	lastRestoreTime       *prometheus.GaugeVec
+	running               *prometheus.GaugeVec
+	checkpointErrors      *prometheus.CounterVec
+	restoreErrors         *prometheus.CounterVec
+	checkpointMemoryBytes *prometheus.GaugeVec
 }
 
 func NewCollector(log *slog.Logger) *Collector {
@@ -93,6 +95,12 @@ func NewCollector(log *slog.Logger) *Collector {
 			Name:      MetricRestoreErrorsTotal,
 			Help:      "Total number of restore errors.",
 		}, commonLabels),
+
+		checkpointMemoryBytes: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Namespace: MetricsNamespace,
+			Name:      MetricCheckpointMemoryBytes,
+			Help:      "Memory pages dumped by criu in bytes.",
+		}, commonLabels),
 	}
 }
 
@@ -136,6 +144,7 @@ func (c *Collector) Collect(ch chan<- prometheus.Metric) {
 			}
 			c.checkpointErrors.With(l).Add(float64(metrics.CheckpointErrors))
 			c.restoreErrors.With(l).Add(float64(metrics.RestoreErrors))
+			c.checkpointMemoryBytes.With(l).Set(float64(metrics.CheckpointMemoryBytes))
 		}
 	}
 	c.running.Collect(ch)
@@ -145,6 +154,7 @@ func (c *Collector) Collect(ch chan<- prometheus.Metric) {
 	c.lastRestoreTime.Collect(ch)
 	c.checkpointErrors.Collect(ch)
 	c.restoreErrors.Collect(ch)
+	c.checkpointMemoryBytes.Collect(ch)
 }
 
 func (c *Collector) Describe(ch chan<- *prometheus.Desc) {
@@ -186,4 +196,5 @@ func (c *Collector) deleteMetrics(status *v1.ContainerStatus) {
 	c.lastRestoreTime.Delete(l)
 	c.checkpointErrors.Delete(l)
 	c.restoreErrors.Delete(l)
+	c.checkpointMemoryBytes.Delete(l)
 }

--- a/manager/node/service.go
+++ b/manager/node/service.go
@@ -13,6 +13,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"reflect"
 	"regexp"
 	"slices"
 	"strconv"
@@ -129,7 +130,12 @@ func NewServer(addr string, kube client.Client, log *slog.Logger, timeouts Timeo
 		cap:                    cap,
 	})
 
-	log.Info("new node server", "name", nodeName, "live_migration_supported", liveMigrationSupported)
+	log.Info("new node server",
+		"name", nodeName,
+		"live_migration_supported", liveMigrationSupported,
+		"capacity_tracker", reflect.TypeOf(cap).String(),
+		"eviction_threshold", cap.Threshold(),
+	)
 	return &Server{
 		ttrpc:        s,
 		unixListener: unixListener,
@@ -340,12 +346,23 @@ func (ns *nodeService) hasCapacity(res corev1.ResourceList) bool {
 	if cpuCap.IsZero() || memCap.IsZero() {
 		return true
 	}
-	if cpuRequested.Cmp(cpuCap) > 0 {
-		ns.log.Info("capacity: not enough cpu", "cap", cpuCap.String(), "req", cpuRequested.String())
+
+	if capacity.CmpThreshold(ns.cap, corev1.ResourceCPU, *cpuRequested) > 0 {
+		ns.log.Info("capacity: not enough cpu",
+			"cap", cpuCap.String(),
+			"total_req", cpuRequested.String(),
+			"container_req", res.Cpu().String(),
+			"threshold", ns.cap.Threshold(),
+		)
 		return false
 	}
-	if memRequested.Cmp(memCap) > 0 {
-		ns.log.Info("capacity: not enough memory", "cap", memCap.String(), "req", memRequested.String())
+	if capacity.CmpThreshold(ns.cap, corev1.ResourceMemory, *memRequested) > 0 {
+		ns.log.Info("capacity: not enough memory",
+			"cap", memCap.String(),
+			"total_req", memRequested.String(),
+			"container_req", res.Memory().String(),
+			"threshold", ns.cap.Threshold(),
+		)
 		return false
 	}
 	return true

--- a/manager/node/service.go
+++ b/manager/node/service.go
@@ -31,6 +31,7 @@ import (
 	"google.golang.org/protobuf/types/known/emptypb"
 	corev1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -230,9 +231,17 @@ func (ns *nodeService) RestoreCapacity(ctx context.Context, req *nodev1.RestoreC
 		log.Error("getting container resources", "error", err)
 		return &nodev1.RestoreCapacityResponse{Allowed: true}, fmt.Errorf("getting container requests: %w", err)
 	}
-	log.Debug("container resources", "cpu", res.Cpu(), "mem", res.Memory())
+
+	if ns.cap.UseCheckpointMemory() && req.CheckpointMemoryBytes != 0 {
+		res[corev1.ResourceMemory] = *resource.NewQuantity(int64(req.CheckpointMemoryBytes), resource.BinarySI)
+	}
+
+	log.Debug("container resources", "cpu", res.Cpu(), "mem", res.Memory(), "use_checkpoint_memory", ns.cap.UseCheckpointMemory())
 	if ns.hasCapacity(res) {
-		log.Debug("node has enough capacity to restore")
+		log.Debug("node has enough capacity to restore",
+			"cpu", ns.cap.Capacity(corev1.ResourceCPU),
+			"mem", ns.cap.Capacity(corev1.ResourceMemory),
+		)
 		return &nodev1.RestoreCapacityResponse{Allowed: true}, nil
 	}
 	resp, err := ns.evictPod(ctx, req, pod)

--- a/manager/node/service_test.go
+++ b/manager/node/service_test.go
@@ -55,6 +55,7 @@ func TestRestoreCapacity(t *testing.T) {
 		node          *corev1.Node
 		pod           *corev1.Pod
 		migration     *v1.Migration
+		threshold     float64
 		containerName string
 		allowed       bool
 		expectedErr   bool
@@ -68,6 +69,7 @@ func TestRestoreCapacity(t *testing.T) {
 			}),
 			containerName: "app1",
 			allowed:       true,
+			threshold:     1.0,
 		},
 		"empty requests": {
 			node: newNode("enough", corev1.ResourceList{
@@ -77,6 +79,7 @@ func TestRestoreCapacity(t *testing.T) {
 			pod:         newPod("empty-req", corev1.ResourceList{}),
 			allowed:     true,
 			expectedErr: false,
+			threshold:   1.0,
 		},
 		"node with enough capacity": {
 			node: newNode("enough", corev1.ResourceList{
@@ -89,6 +92,7 @@ func TestRestoreCapacity(t *testing.T) {
 			}),
 			containerName: "app1",
 			allowed:       true,
+			threshold:     1.0,
 		},
 		"node at memory capacity": {
 			node: newNode("full-mem", corev1.ResourceList{
@@ -102,6 +106,35 @@ func TestRestoreCapacity(t *testing.T) {
 			migration:     newMigration("10.0.0.1"),
 			containerName: "app1",
 			allowed:       false,
+			threshold:     1.0,
+		},
+		"node at memory capacity because of low threshold": {
+			node: newNode("full-mem", corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("4"),
+				corev1.ResourceMemory: resource.MustParse("20Gi"),
+			}),
+			pod: newPod("app1", corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("10m"),
+				corev1.ResourceMemory: resource.MustParse("4Gi"),
+			}),
+			migration:     newMigration("10.0.0.1"),
+			containerName: "app1",
+			allowed:       false,
+			threshold:     0.1,
+		},
+		"node at cpu capacity because of low threshold": {
+			node: newNode("full-mem", corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("4"),
+				corev1.ResourceMemory: resource.MustParse("20Gi"),
+			}),
+			pod: newPod("app1", corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("1"),
+				corev1.ResourceMemory: resource.MustParse("10Mi"),
+			}),
+			migration:     newMigration("10.0.0.1"),
+			containerName: "app1",
+			allowed:       false,
+			threshold:     0.1,
 		},
 		"pod with resources in annotation": {
 			node: newNode("full-mem", corev1.ResourceList{
@@ -116,6 +149,7 @@ func TestRestoreCapacity(t *testing.T) {
 			containerName: "app1",
 			allowed:       false,
 			podScaledDown: true,
+			threshold:     1.0,
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
@@ -130,7 +164,7 @@ func TestRestoreCapacity(t *testing.T) {
 				objs = append(objs, tc.migration)
 			}
 			kube := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).Build()
-			cap := capacity.NewNodeTracker(prometheus.NewRegistry(), "name")
+			cap := capacity.NewNodeTracker(prometheus.NewRegistry(), "name", tc.threshold)
 			for name, q := range tc.node.Status.Capacity {
 				cap.SetCapacity(name, q)
 			}

--- a/manager/pod_controller.go
+++ b/manager/pod_controller.go
@@ -362,8 +362,8 @@ func (r podReconciler) updateNodeResources(ctx context.Context) (time.Duration, 
 	if ok && time.Since(timeAdded) < capacity.MinTaintDuration {
 		return capacity.MinTaintDuration, nil
 	}
-	if ok && node.Status.Capacity.Cpu().Cmp(cpuRequested) == 1 &&
-		node.Status.Capacity.Memory().Cmp(memRequested) == 1 {
+	if ok && capacity.CmpThreshold(r.cap, corev1.ResourceCPU, cpuRequested) == -1 &&
+		capacity.CmpThreshold(r.cap, corev1.ResourceMemory, memRequested) == -1 {
 		capacity.RemoveTaint(node)
 		r.log.Info("removing taint from node", "node", node.Name)
 		if err := r.kube.Update(ctx, node); err != nil {

--- a/shim/checkpoint.go
+++ b/shim/checkpoint.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/checkpoint-restore/go-criu/v8/stats"
 	"github.com/containerd/containerd/v2/cmd/containerd-shim-runc-v2/process"
 	runcC "github.com/containerd/go-runc"
 	"github.com/containerd/log"
@@ -19,6 +20,7 @@ import (
 	nodev1 "github.com/ctrox/zeropod/api/node/v1"
 	v1 "github.com/ctrox/zeropod/api/shim/v1"
 	"github.com/icza/backscanner"
+	"golang.org/x/sys/unix"
 )
 
 func (c *Container) scaleDown(ctx context.Context) error {
@@ -142,6 +144,18 @@ func (c *Container) checkpoint(ctx context.Context) error {
 		log.G(ctx).Errorf("error checkpointing container: %s", err)
 		resetOnErr()
 		return err
+	}
+
+	imgDir, err := os.Open(nodev1.WorkDirPath(c.ID()))
+	if err != nil {
+		return err
+	}
+
+	dumpStats, err := stats.CriuGetDumpStats(imgDir)
+	if err != nil {
+		log.G(ctx).WithError(err).Error("getting criu dump stats")
+	} else {
+		c.metrics.CheckpointMemoryBytes = dumpStats.GetPagesWritten() * uint64(unix.Getpagesize())
 	}
 
 	c.setPhaseNotify(v1.ContainerPhase_SCALED_DOWN, time.Since(beforeCheckpoint))

--- a/shim/checkpoint.go
+++ b/shim/checkpoint.go
@@ -12,7 +12,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/checkpoint-restore/go-criu/v8/stats"
 	"github.com/containerd/containerd/v2/cmd/containerd-shim-runc-v2/process"
 	runcC "github.com/containerd/go-runc"
 	"github.com/containerd/log"
@@ -20,7 +19,6 @@ import (
 	nodev1 "github.com/ctrox/zeropod/api/node/v1"
 	v1 "github.com/ctrox/zeropod/api/shim/v1"
 	"github.com/icza/backscanner"
-	"golang.org/x/sys/unix"
 )
 
 func (c *Container) scaleDown(ctx context.Context) error {
@@ -144,18 +142,6 @@ func (c *Container) checkpoint(ctx context.Context) error {
 		log.G(ctx).Errorf("error checkpointing container: %s", err)
 		resetOnErr()
 		return err
-	}
-
-	imgDir, err := os.Open(nodev1.WorkDirPath(c.ID()))
-	if err != nil {
-		return err
-	}
-
-	dumpStats, err := stats.CriuGetDumpStats(imgDir)
-	if err != nil {
-		log.G(ctx).WithError(err).Error("getting criu dump stats")
-	} else {
-		c.metrics.CheckpointMemoryBytes = dumpStats.GetPagesWritten() * uint64(unix.Getpagesize())
 	}
 
 	c.setPhaseNotify(v1.ContainerPhase_SCALED_DOWN, time.Since(beforeCheckpoint))

--- a/shim/container.go
+++ b/shim/container.go
@@ -267,6 +267,9 @@ func (c *Container) setPhase(phase v1.ContainerPhase, duration time.Duration) {
 		}
 		c.scaledDown = true
 		c.metrics.Running = false
+		if err := c.updateCheckpointMemoryBytes(); err != nil {
+			log.G(c.context).WithError(err).Error("updating checkpoint memory metric")
+		}
 	}
 }
 

--- a/shim/metrics.go
+++ b/shim/metrics.go
@@ -1,7 +1,13 @@
 package shim
 
 import (
+	"os"
+	"path/filepath"
+
+	"github.com/checkpoint-restore/go-criu/v8/stats"
+	nodev1 "github.com/ctrox/zeropod/api/node/v1"
 	v1 "github.com/ctrox/zeropod/api/shim/v1"
+	"golang.org/x/sys/unix"
 )
 
 func newMetrics(cfg *v1.Config, running bool) *v1.ContainerMetrics {
@@ -11,4 +17,27 @@ func newMetrics(cfg *v1.Config, running bool) *v1.ContainerMetrics {
 		PodNamespace: cfg.PodNamespace,
 		Running:      running,
 	}
+}
+
+func (c *Container) updateCheckpointMemoryBytes() error {
+	if _, err := os.Stat(filepath.Join(nodev1.WorkDirPath(c.ID()), stats.StatsDump)); err == nil {
+		// move stats file to the snapshot path so it gets migrated
+		err := os.Rename(
+			filepath.Join(nodev1.WorkDirPath(c.ID()), stats.StatsDump),
+			filepath.Join(nodev1.SnapshotPath(c.ID()), stats.StatsDump),
+		)
+		if err != nil {
+			return err
+		}
+	}
+	imgDir, err := os.Open(nodev1.SnapshotPath(c.ID()))
+	if err != nil {
+		return err
+	}
+	dumpStats, err := stats.CriuGetDumpStats(imgDir)
+	if err != nil {
+		return nil
+	}
+	c.metrics.CheckpointMemoryBytes = dumpStats.GetPagesWritten() * uint64(unix.Getpagesize())
+	return nil
 }

--- a/shim/restore_capacity.go
+++ b/shim/restore_capacity.go
@@ -27,6 +27,7 @@ func (c *Container) restoreCapacityRequest(ctx context.Context) (*nodev1.Restore
 			Namespace:     c.cfg.PodNamespace,
 			ContainerName: c.cfg.ContainerName,
 		},
+		CheckpointMemoryBytes: c.metrics.CheckpointMemoryBytes,
 	}
 	nodeClient := nodev1.NewNodeClient(ttrpc.NewClient(conn))
 	resp, err := nodeClient.RestoreCapacity(ctx, restoreCapReq)


### PR DESCRIPTION
* adds a system memory mode where usage is measured by actual system memory and the requested container sends an approximation of how much memory it will use (derived from checkpoint stats).
* adds a threshold so evictions can be configured to start below/above the default 100%